### PR TITLE
ch01/ex03のリファクタリング

### DIFF
--- a/ch01/ex03/ex03_test.go
+++ b/ch01/ex03/ex03_test.go
@@ -9,16 +9,12 @@ import (
 )
 
 func BenchmarkForLoop(b *testing.B) {
-	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
 		ForLoop()
 	}
 }
 
 func BenchmarkStringsJoin(b *testing.B) {
-	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
 		StringsJoin()
 	}

--- a/ch01/ex03/main.go
+++ b/ch01/ex03/main.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-var arr = []string{"abc", "efg"}
+var arr = []string{"abc", "efg", "hij", "xyz", "0123456789"}
 
 func ForLoop() {
 	var s, sep string


### PR DESCRIPTION
- b.ResetTimer()はタイマーを止めて行う初期処理がないため不要
- ベンチマークテストするにはarrの文字列数が足りないので追加